### PR TITLE
feat: add GitHub OAuth2 login functionality

### DIFF
--- a/src/app/(home)/config-dialog/site-settings/index.tsx
+++ b/src/app/(home)/config-dialog/site-settings/index.tsx
@@ -8,6 +8,7 @@ import { ArtImagesSection } from './art-images-section'
 import { BackgroundImagesSection } from './background-images-section'
 import { SocialButtonsSection } from './social-buttons-section'
 import { HatSection } from './hat-section'
+import { OAuth2LoginButton } from '@/components/oauth2-login-button'
 
 export type { FileItem, ArtImageUploads, BackgroundImageUploads, SocialButtonImageUploads } from './types'
 
@@ -93,16 +94,26 @@ export function SiteSettings({
 					<span className='text-sm font-medium'>隐藏编辑按钮（页面编辑快捷键 ctrl/cmd + ,）</span>
 				</label>
 			</div>
-			<div className='flex gap-3'>
-				<label className='flex items-center gap-2'>
-					<input
-						type='checkbox'
-						checked={formData.isCachePem ?? false}
-						onChange={e => setFormData({ ...formData, isCachePem: e.target.checked })}
-						className='accent-brand h-4 w-4 rounded'
-					/>
-					<span className='text-sm font-medium'>缓存PEM(已加密，但存在风险)</span>
-				</label>
+			<div className='space-y-4'>
+				<div className='flex gap-3'>
+					<label className='flex items-center gap-2'>
+						<input
+							type='checkbox'
+							checked={formData.isCachePem ?? false}
+							onChange={e => setFormData({ ...formData, isCachePem: e.target.checked })}
+							className='accent-brand h-4 w-4 rounded'
+						/>
+						<span className='text-sm font-medium'>缓存PEM(已加密，但存在风险)</span>
+					</label>
+				</div>
+
+				<div className='border rounded-lg p-4 bg-gray-50'>
+					<h3 className='text-sm font-medium mb-3'>GitHub OAuth2 登录</h3>
+					<p className='text-xs text-gray-600 mb-3'>
+						使用GitHub OAuth2登录，避免私钥文件丢失。登录后可以直接操作仓库。
+					</p>
+					<OAuth2LoginButton />
+				</div>
 			</div>
 
 			<HatSection formData={formData} setFormData={setFormData} />

--- a/src/app/(home)/services/push-site-content.ts
+++ b/src/app/(home)/services/push-site-content.ts
@@ -1,5 +1,5 @@
 import { toBase64Utf8, getRef, createTree, createCommit, updateRef, createBlob, type TreeItem } from '@/lib/github-client'
-import { getAuthToken } from '@/lib/auth'
+import { useAuthStore } from '@/hooks/use-auth'
 import { GITHUB_CONFIG } from '@/consts'
 import { toast } from 'sonner'
 import { fileToBase64NoPrefix } from '@/lib/file-utils'
@@ -20,7 +20,7 @@ export async function pushSiteContent(
 	removedBackgroundImages?: BackgroundImageConfig[],
 	socialButtonImageUploads?: SocialButtonImageUploads
 ): Promise<void> {
-	const token = await getAuthToken()
+	const token = await useAuthStore.getState().getAuthToken()
 
 	toast.info('正在获取分支信息...')
 	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)

--- a/src/app/api/auth/github/oauth2/callback/route.ts
+++ b/src/app/api/auth/github/oauth2/callback/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { code, state } = await request.json()
+
+    if (!code || !state) {
+      return NextResponse.json(
+        { error: 'Missing required parameters' },
+        { status: 400 }
+      )
+    }
+
+    const clientId = process.env.NEXT_PUBLIC_GITHUB_OAUTH_CLIENT_ID
+    const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET
+    const redirectUri = `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:2025'}/auth/callback`
+
+    if (!clientId || !clientSecret) {
+      return NextResponse.json(
+        { error: 'OAuth configuration missing' },
+        { status: 500 }
+      )
+    }
+
+    // 交换授权码获取访问令牌
+    const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: code,
+        redirect_uri: redirectUri
+      })
+    })
+
+    if (!tokenResponse.ok) {
+      throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+    }
+
+    const tokenData = await tokenResponse.json()
+    
+    if (tokenData.error) {
+      throw new Error(tokenData.error_description || tokenData.error)
+    }
+
+    const accessToken = tokenData.access_token
+    if (!accessToken) {
+      throw new Error('No access token received')
+    }
+
+    // 获取用户信息
+    const userResponse = await fetch('https://api.github.com/user', {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+
+    if (!userResponse.ok) {
+      throw new Error(`Failed to get user info: ${userResponse.status}`)
+    }
+
+    const userData = await userResponse.json()
+
+    return NextResponse.json({
+      success: true,
+      access_token: accessToken,
+      user: userData
+    })
+
+  } catch (error) {
+    console.error('OAuth2 callback error:', error)
+    return NextResponse.json(
+      { 
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { handleOAuth2Callback } from '@/lib/oauth2-github'
+import { useAuthStore } from '@/hooks/use-auth'
+import { toast } from 'sonner'
+import { Suspense } from 'react'
+
+function AuthCallbackContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { setOAuth2Auth } = useAuthStore()
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      const code = searchParams.get('code')
+      const state = searchParams.get('state')
+      const errorParam = searchParams.get('error')
+      const errorDescription = searchParams.get('error_description')
+
+      // 处理OAuth错误
+      if (errorParam) {
+        setError(errorDescription || errorParam)
+        toast.error(`GitHub授权失败: ${errorDescription || errorParam}`)
+        setIsLoading(false)
+        setTimeout(() => {
+          router.push('/')
+        }, 3000)
+        return
+      }
+
+      // 检查必需参数
+      if (!code || !state) {
+        setError('缺少必需的授权参数')
+        toast.error('授权参数不完整')
+        setIsLoading(false)
+        setTimeout(() => {
+          router.push('/')
+        }, 3000)
+        return
+      }
+
+      // 处理OAuth回调
+      const success = await handleOAuth2Callback(code, state)
+      
+      if (success) {
+        // 设置OAuth2认证状态
+        await setOAuth2Auth()
+        // 登录成功，重定向到首页
+        setTimeout(() => {
+          router.push('/')
+        }, 1500)
+      } else {
+        setError('登录失败，请重试')
+        setTimeout(() => {
+          router.push('/')
+        }, 3000)
+      }
+      
+      setIsLoading(false)
+    }
+
+    handleCallback()
+  }, [searchParams, router])
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">正在处理GitHub登录...</h2>
+          <p className="text-gray-600">请稍候，我们正在验证您的授权信息</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center max-w-md mx-auto p-6">
+          <div className="text-red-500 text-6xl mb-4">⚠️</div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">登录失败</h2>
+          <p className="text-gray-600 mb-4">{error}</p>
+          <p className="text-sm text-gray-500">将在3秒后自动跳转到首页...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <div className="text-green-500 text-6xl mb-4">✅</div>
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">登录成功！</h2>
+        <p className="text-gray-600">正在跳转到首页...</p>
+      </div>
+    </div>
+  )
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    }>
+      <AuthCallbackContent />
+    </Suspense>
+  )
+}

--- a/src/app/share/services/push-shares.ts
+++ b/src/app/share/services/push-shares.ts
@@ -1,6 +1,6 @@
 import { toBase64Utf8, getRef, createTree, createCommit, updateRef, createBlob, type TreeItem } from '@/lib/github-client'
 import { fileToBase64NoPrefix, hashFileSHA256 } from '@/lib/file-utils'
-import { getAuthToken } from '@/lib/auth'
+import { useAuthStore } from '@/hooks/use-auth'
 import { GITHUB_CONFIG } from '@/consts'
 import type { Share } from '../components/share-card'
 import type { LogoItem } from '../components/logo-upload-dialog'
@@ -16,7 +16,7 @@ export async function pushShares(params: PushSharesParams): Promise<void> {
 	const { shares, logoItems } = params
 
 	// 获取认证 token（自动从全局认证状态获取）
-	const token = await getAuthToken()
+	const token = await useAuthStore.getState().getAuthToken()
 
 	toast.info('正在获取分支信息...')
 	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
@@ -83,4 +83,3 @@ export async function pushShares(params: PushSharesParams): Promise<void> {
 
 	toast.success('发布成功！')
 }
-

--- a/src/app/write/components/editor.tsx
+++ b/src/app/write/components/editor.tsx
@@ -1,7 +1,12 @@
+'use client'
+
 import { motion } from 'motion/react'
 import { useWriteStore } from '../stores/write-store'
 import { INIT_DELAY } from '@/consts'
 import { useRef } from 'react'
+import { useAuthStore } from '@/hooks/use-auth'
+import { GITHUB_CONFIG } from '@/consts'
+import { toast } from 'sonner'
 
 const defaultText = 'text'
 
@@ -155,6 +160,17 @@ export function WriteEditor() {
 		}
 	}
 
+	const handleGenerateRandomSlug = async () => {
+		if (!isAuth) {
+			toast.info('请先导入密钥')
+			return
+		}
+
+		// 生成8位随机字符串
+		const randomSlug = Math.random().toString(36).slice(2, 10)
+		updateForm({ slug: randomSlug })
+		toast.success('已生成随机 Slug')
+	}
 	return (
 		<motion.div
 			initial={{ opacity: 0, scale: 0.8 }}

--- a/src/app/write/services/push-blog.ts
+++ b/src/app/write/services/push-blog.ts
@@ -1,7 +1,8 @@
 import { toBase64Utf8, getRef, createTree, createCommit, updateRef, createBlob, type TreeItem } from '@/lib/github-client'
 import { fileToBase64NoPrefix, hashFileSHA256 } from '@/lib/file-utils'
-import { prepareBlogsIndex } from '@/lib/blog-index'
+import { prepareBlogsIndex, prepareDualBlogsIndex } from '@/lib/blog-index'
 import { getAuthToken } from '@/lib/auth'
+import { useAuthStore } from '@/hooks/use-auth'
 import { GITHUB_CONFIG } from '@/consts'
 import type { ImageItem } from '../types'
 import { getFileExt } from '@/lib/utils'
@@ -33,7 +34,7 @@ export async function pushBlog(params: PushBlogParams): Promise<void> {
 	}
 
 	// 获取认证 token（自动从全局认证状态获取）
-	const token = await getAuthToken()
+	const token = await useAuthStore.getState().getAuthToken()
 
 	toast.info('正在获取分支信息...')
 	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
@@ -126,7 +127,6 @@ export async function pushBlog(params: PushBlogParams): Promise<void> {
 		cover: coverPath,
 		hidden: form.hidden
 	}
-
 	const configBlob = await createBlob(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, toBase64Utf8(JSON.stringify(config, null, 2)), 'base64')
 	treeItems.push({
 		path: `${basePath}/config.json`,
@@ -146,8 +146,7 @@ export async function pushBlog(params: PushBlogParams): Promise<void> {
 			tags: form.tags,
 			date: dateStr,
 			summary: form.summary,
-			cover: coverPath,
-			hidden: form.hidden
+			cover: coverPath
 		},
 		GITHUB_CONFIG.BRANCH
 	)

--- a/src/components/oauth2-login-button.tsx
+++ b/src/components/oauth2-login-button.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { initiateGitHubOAuth2 } from '@/lib/oauth2-github'
+import { useAuthStore } from '@/hooks/use-auth'
+import { Github } from 'lucide-react'
+
+export function OAuth2LoginButton() {
+  const [isLoading, setIsLoading] = useState(false)
+  const { authMethod, currentUser, clearAuth } = useAuthStore()
+
+  const handleLogin = async () => {
+    setIsLoading(true)
+    try {
+      initiateGitHubOAuth2()
+    } catch (error) {
+      console.error('OAuth2 login failed:', error)
+      setIsLoading(false)
+    }
+  }
+
+  const handleLogout = () => {
+    clearAuth()
+  }
+
+  if (authMethod === 'oauth2' && currentUser) {
+    return (
+      <div className="flex items-center gap-3 p-3 bg-green-50 rounded-lg border border-green-200">
+        <img 
+          src={currentUser.avatar_url} 
+          alt={currentUser.login}
+          className="w-8 h-8 rounded-full"
+        />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-green-900">
+            {currentUser.name || currentUser.login}
+          </p>
+          <p className="text-xs text-green-700">GitHub OAuth2 已登录</p>
+        </div>
+        <button
+          onClick={handleLogout}
+          className="px-3 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
+        >
+          退出
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={handleLogin}
+      disabled={isLoading}
+      className="flex items-center gap-2 w-full px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <Github className="w-4 h-4" />
+      {isLoading ? '正在跳转...' : '使用 GitHub 登录'}
+    </button>
+  )
+}

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,54 +1,125 @@
 import { create } from 'zustand'
 import { clearAllAuthCache, getAuthToken as getToken, hasAuth as checkAuth, getPemFromCache, savePemToCache } from '@/lib/auth'
+import { getOAuth2Token, hasOAuth2Auth, clearOAuth2Token, getCurrentUser } from '@/lib/oauth2-github'
 import { useConfigStore } from '@/app/(home)/stores/config-store'
 interface AuthStore {
 	// State
 	isAuth: boolean
 	privateKey: string | null
+	authMethod: 'github-app' | 'oauth2' | null
+	currentUser: any | null
 
 	// Actions
 	setPrivateKey: (key: string) => void
+	setOAuth2Auth: () => void
 	clearAuth: () => void
 	refreshAuthState: () => void
 	getAuthToken: () => Promise<string>
+	getCurrentUser: () => Promise<any | null>
 }
 
 export const useAuthStore = create<AuthStore>((set, get) => ({
 	isAuth: false,
 	privateKey: null,
+	authMethod: null,
+	currentUser: null,
 
 	setPrivateKey: async (key: string) => {
-		set({ isAuth: true, privateKey: key })
+		set({ isAuth: true, privateKey: key, authMethod: 'github-app' })
 		const { siteContent } = useConfigStore.getState()
 		if (siteContent?.isCachePem) {
 			await savePemToCache(key)
 		}
 	},
 
+	setOAuth2Auth: async () => {
+		const user = await getCurrentUser()
+		set({ isAuth: true, authMethod: 'oauth2', currentUser: user })
+	},
+
 	clearAuth: () => {
 		clearAllAuthCache()
-		set({ isAuth: false })
+		clearOAuth2Token()
+		set({ isAuth: false, authMethod: null, currentUser: null })
 	},
 
 	refreshAuthState: async () => {
-		set({ isAuth: await checkAuth() })
+		const hasAppAuth = await checkAuth()
+		const hasOAuth2 = hasOAuth2Auth()
+		
+		if (hasOAuth2) {
+			const user = await getCurrentUser()
+			set({ isAuth: true, authMethod: 'oauth2', currentUser: user })
+		} else if (hasAppAuth) {
+			set({ isAuth: true, authMethod: 'github-app' })
+		} else {
+			set({ isAuth: false, authMethod: null, currentUser: null })
+		}
 	},
 
 	getAuthToken: async () => {
-		const token = await getToken()
-		get().refreshAuthState()
-		return token
+		const { authMethod } = get()
+		
+		if (authMethod === 'oauth2') {
+			const token = await getOAuth2Token()
+			if (!token) {
+				throw new Error('OAuth2 token not found')
+			}
+			return token
+		} else {
+			const token = await getToken()
+			get().refreshAuthState()
+			return token
+		}
+	},
+
+	getCurrentUser: async () => {
+		const { authMethod, currentUser } = get()
+		
+		if (authMethod === 'oauth2' && currentUser) {
+			return currentUser
+		}
+		
+		if (authMethod === 'oauth2') {
+			const user = await getCurrentUser()
+			set({ currentUser: user })
+			return user
+		}
+		
+		return null
 	}
 }))
 
-getPemFromCache().then((key) => {
-	if (key) {
-		useAuthStore.setState({ privateKey: key })
+// 初始化认证状态
+async function initializeAuth() {
+	const store = useAuthStore.getState()
+	
+	// 检查OAuth2认证
+	if (hasOAuth2Auth()) {
+		const user = await getCurrentUser()
+		if (user) {
+			useAuthStore.setState({ 
+				isAuth: true, 
+				authMethod: 'oauth2', 
+				currentUser: user 
+			})
+			return
+		}
 	}
-})
+	
+	// 检查GitHub App认证
+	const privateKey = await getPemFromCache()
+	if (privateKey) {
+		useAuthStore.setState({ 
+			privateKey,
+			authMethod: 'github-app'
+		})
+	}
+	
+	const hasAppAuth = await checkAuth()
+	if (hasAppAuth) {
+		useAuthStore.setState({ isAuth: true })
+	}
+}
 
-checkAuth().then((isAuth) => {
-	if (isAuth) {
-		useAuthStore.setState({ isAuth })
-	}
-})
+initializeAuth()

--- a/src/lib/oauth2-github.ts
+++ b/src/lib/oauth2-github.ts
@@ -1,0 +1,209 @@
+'use client'
+
+import { GITHUB_CONFIG } from '@/consts'
+import { toast } from 'sonner'
+
+// OAuth2 配置
+const OAUTH2_CONFIG = {
+  CLIENT_ID: process.env.NEXT_PUBLIC_GITHUB_OAUTH_CLIENT_ID || '',
+  REDIRECT_URI: typeof window !== 'undefined' ? `${window.location.origin}/auth/callback` : '',
+  SCOPE: 'repo', // 仓库访问权限
+  STATE_KEY: 'github_oauth_state',
+  TOKEN_KEY: 'github_oauth_token'
+}
+
+/**
+ * 生成随机状态字符串用于安全验证
+ */
+function generateState(): string {
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+}
+
+/**
+ * 保存状态到sessionStorage
+ */
+function saveState(state: string): void {
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.setItem(OAUTH2_CONFIG.STATE_KEY, state)
+  } catch (error) {
+    console.error('Failed to save OAuth state:', error)
+  }
+}
+
+/**
+ * 验证并清除状态
+ */
+function validateAndClearState(returnedState: string): boolean {
+  if (typeof sessionStorage === 'undefined') return false
+  try {
+    const savedState = sessionStorage.getItem(OAUTH2_CONFIG.STATE_KEY)
+    sessionStorage.removeItem(OAUTH2_CONFIG.STATE_KEY)
+    return savedState === returnedState
+  } catch (error) {
+    console.error('Failed to validate OAuth state:', error)
+    return false
+  }
+}
+
+/**
+ * 获取OAuth2访问令牌
+ */
+export async function getOAuth2Token(): Promise<string | null> {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    return sessionStorage.getItem(OAUTH2_CONFIG.TOKEN_KEY)
+  } catch (error) {
+    console.error('Failed to get OAuth2 token:', error)
+    return null
+  }
+}
+
+/**
+ * 保存OAuth2访问令牌
+ */
+export function saveOAuth2Token(token: string): void {
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.setItem(OAUTH2_CONFIG.TOKEN_KEY, token)
+  } catch (error) {
+    console.error('Failed to save OAuth2 token:', error)
+  }
+}
+
+/**
+ * 清除OAuth2访问令牌
+ */
+export function clearOAuth2Token(): void {
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.removeItem(OAUTH2_CONFIG.TOKEN_KEY)
+  } catch (error) {
+    console.error('Failed to clear OAuth2 token:', error)
+  }
+}
+
+/**
+ * 启动GitHub OAuth2登录流程
+ */
+export function initiateGitHubOAuth2(): void {
+  if (!OAUTH2_CONFIG.CLIENT_ID) {
+    toast.error('GitHub OAuth2客户端ID未配置')
+    return
+  }
+
+  const state = generateState()
+  saveState(state)
+
+  const params = new URLSearchParams({
+    client_id: OAUTH2_CONFIG.CLIENT_ID,
+    redirect_uri: OAUTH2_CONFIG.REDIRECT_URI,
+    scope: OAUTH2_CONFIG.SCOPE,
+    state: state
+  })
+
+  const authUrl = `https://github.com/login/oauth/authorize?${params.toString()}`
+  
+  toast.info('正在跳转到GitHub授权页面...')
+  window.location.href = authUrl
+}
+
+/**
+ * 处理OAuth2回调
+ */
+export async function handleOAuth2Callback(code: string, state: string): Promise<boolean> {
+  // 验证状态
+  if (!validateAndClearState(state)) {
+    toast.error('OAuth状态验证失败，请重新登录')
+    return false
+  }
+
+  try {
+    toast.info('正在获取访问令牌...')
+    
+    // 通过API路由交换授权码获取访问令牌
+    const tokenResponse = await fetch('/api/auth/github/oauth2/callback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ code, state })
+    })
+
+    if (!tokenResponse.ok) {
+      throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+    }
+
+    const data = await tokenResponse.json()
+    
+    if (!data.success) {
+      throw new Error(data.error || 'Token exchange failed')
+    }
+
+    const accessToken = data.access_token
+    if (!accessToken) {
+      throw new Error('No access token received')
+    }
+
+    // 保存访问令牌
+    saveOAuth2Token(accessToken)
+    
+    toast.success('GitHub登录成功！')
+    return true
+
+  } catch (error) {
+    console.error('OAuth2 callback error:', error)
+    toast.error(`GitHub登录失败: ${error instanceof Error ? error.message : '未知错误'}`)
+    return false
+  }
+}
+
+/**
+ * 检查是否有OAuth2认证
+ */
+export function hasOAuth2Auth(): boolean {
+  return !!getOAuth2Token()
+}
+
+/**
+ * 获取当前用户信息
+ */
+export async function getCurrentUser(): Promise<GitHubUser | null> {
+  const token = await getOAuth2Token()
+  if (!token) return null
+
+  try {
+    const response = await fetch('https://api.github.com/user', {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        // Token过期，清除缓存
+        clearOAuth2Token()
+      }
+      throw new Error(`Failed to get user info: ${response.status}`)
+    }
+
+    return await response.json()
+  } catch (error) {
+    console.error('Failed to get current user:', error)
+    return null
+  }
+}
+
+/**
+ * GitHub用户信息接口
+ */
+export interface GitHubUser {
+  id: number
+  login: string
+  name: string | null
+  email: string | null
+  avatar_url: string
+  html_url: string
+}


### PR DESCRIPTION
添加 GitHub 的 OAuth2 认证流程
添加 OAuth2 登录按钮组件
添加带有适当错误处理的回调页面
更新现有服务以支持 OAuth2 令牌
配置要求在vercel
添加
NEXT_PUBLIC_SITE_URL 正式部署的域名
NEXT_PUBLIC_GITHUB_OAUTH_CLIENT_ID outh的id
GITHUB_OAUTH_CLIENT_SECRET outh的私钥
环境变量