### PR TITLE
Pr：修复了编码解析过度问题

### DIFF
--- a/src/app/(home)/services/push-site-content.ts
+++ b/src/app/(home)/services/push-site-content.ts
@@ -23,7 +23,7 @@ export async function pushSiteContent(
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新站点配置`
@@ -195,7 +195,7 @@ export async function pushSiteContent(
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitMessage, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('保存成功！')
 }

--- a/src/app/about/services/push-about.ts
+++ b/src/app/about/services/push-about.ts
@@ -13,7 +13,7 @@ export async function pushAbout(data: AboutData): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新关于页面`
@@ -38,7 +38,7 @@ export async function pushAbout(data: AboutData): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitMessage, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/blog/services/batch-delete-blogs.ts
+++ b/src/app/blog/services/batch-delete-blogs.ts
@@ -13,7 +13,7 @@ export async function batchDeleteBlogs(slugs: string[]): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const treeItems: TreeItem[] = []
@@ -49,7 +49,7 @@ export async function batchDeleteBlogs(slugs: string[]): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitLabel, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('删除成功！请等待页面部署后刷新')
 }

--- a/src/app/blog/services/save-blog-edits.ts
+++ b/src/app/blog/services/save-blog-edits.ts
@@ -11,7 +11,7 @@ export async function saveBlogEdits(originalItems: BlogIndexItem[], nextItems: B
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const treeItems: TreeItem[] = []
@@ -67,7 +67,7 @@ export async function saveBlogEdits(originalItems: BlogIndexItem[], nextItems: B
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitLabel, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('保存成功！请等待页面部署后刷新')
 }

--- a/src/app/bloggers/services/push-bloggers.ts
+++ b/src/app/bloggers/services/push-bloggers.ts
@@ -19,7 +19,7 @@ export async function pushBloggers(params: PushBloggersParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新博主列表`
@@ -79,7 +79,7 @@ export async function pushBloggers(params: PushBloggersParams): Promise<void> {
 
 	// Update branch reference
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/pictures/services/push-pictures.ts
+++ b/src/app/pictures/services/push-pictures.ts
@@ -18,7 +18,7 @@ export async function pushPictures(params: PushPicturesParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新图床列表`
@@ -141,7 +141,7 @@ export async function pushPictures(params: PushPicturesParams): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitMessage, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/projects/services/push-projects.ts
+++ b/src/app/projects/services/push-projects.ts
@@ -18,7 +18,7 @@ export async function pushProjects(params: PushProjectsParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新项目列表`
@@ -72,7 +72,7 @@ export async function pushProjects(params: PushProjectsParams): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitMessage, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/share/services/push-shares.ts
+++ b/src/app/share/services/push-shares.ts
@@ -19,7 +19,7 @@ export async function pushShares(params: PushSharesParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新分享列表`
@@ -79,7 +79,7 @@ export async function pushShares(params: PushSharesParams): Promise<void> {
 
 	// Update branch reference
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/snippets/services/push-snippets.ts
+++ b/src/app/snippets/services/push-snippets.ts
@@ -13,7 +13,7 @@ export async function pushSnippets(params: PushSnippetsParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const commitMessage = `更新句子列表`
@@ -38,7 +38,7 @@ export async function pushSnippets(params: PushSnippetsParams): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, commitMessage, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/app/write/services/delete-blog.ts
+++ b/src/app/write/services/delete-blog.ts
@@ -10,7 +10,7 @@ export async function deleteBlog(slug: string): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const basePath = `public/blogs/${slug}`
@@ -43,7 +43,7 @@ export async function deleteBlog(slug: string): Promise<void> {
 	const commitData = await createCommit(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `删除文章: ${slug}`, treeData.sha, [latestCommitSha])
 
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('删除成功！请等待页面部署后刷新')
 }

--- a/src/app/write/services/push-blog.ts
+++ b/src/app/write/services/push-blog.ts
@@ -38,7 +38,7 @@ export async function pushBlog(params: PushBlogParams): Promise<void> {
 	const token = await getAuthToken()
 
 	toast.info('正在获取分支信息...')
-	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`)
+	const refData = await getRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH)
 	const latestCommitSha = refData.sha
 
 	const basePath = `public/blogs/${form.slug}`
@@ -173,7 +173,7 @@ export async function pushBlog(params: PushBlogParams): Promise<void> {
 
 	// update branch reference
 	toast.info('正在更新分支...')
-	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, `heads/${GITHUB_CONFIG.BRANCH}`, commitData.sha)
+	await updateRef(token, GITHUB_CONFIG.OWNER, GITHUB_CONFIG.REPO, GITHUB_CONFIG.BRANCH, commitData.sha)
 
 	toast.success('发布成功！')
 }

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -99,7 +99,7 @@ export async function putFile(token: string, owner: string, repo: string, path: 
 // Batch commit APIs
 
 export async function getRef(token: string, owner: string, repo: string, ref: string): Promise<{ sha: string }> {
-	const res = await fetch(`${GH_API}/repos/${owner}/${repo}/git/ref/${encodeURIComponent(ref)}`, {
+	const res = await fetch(`${GH_API}/repos/${owner}/${repo}/git/ref/heads/${encodeURIComponent(ref)}`, {
 		headers: {
 			Authorization: `Bearer ${token}`,
 			Accept: 'application/vnd.github+json',

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -158,7 +158,7 @@ export async function createCommit(token: string, owner: string, repo: string, m
 }
 
 export async function updateRef(token: string, owner: string, repo: string, ref: string, sha: string, force = false): Promise<void> {
-	const res = await fetch(`${GH_API}/repos/${owner}/${repo}/git/refs/${encodeURIComponent(ref)}`, {
+	const res = await fetch(`${GH_API}/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(ref)}`, {
 		method: 'PATCH',
 		headers: {
 			Authorization: `Bearer ${token}`,


### PR DESCRIPTION
github-client.ts文件中的：getRef()和updateRef()方法中传入${encodeURIComponent(ref)}在别的文件中是‘heads/${GITHUB_CONFIG.BRANCH}’，在这种情况heads/中的“/”斜杠存在被过度解析成%2的风险。